### PR TITLE
fix: remove blender import to avoid warning

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,10 @@ config/name="Awesome-game-jam-01"
 run/main_scene="res://scenes/main.tscn"
 config/features=PackedStringArray("4.1", "GL Compatibility")
 
+[filesystem]
+
+import/blender/enabled=false
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Fix warning:

`modules/gltf/register_types.cpp:73 - Blend file import is enabled in the project settings, but no Blender path is configured in the editor settings. Blend files will not be imported.`